### PR TITLE
Expose the transport as a standalone object

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ const options = {
     handleExceptions: true, // boolean. It defaults to `true`
     level: 'debug', // (optional) WinstonLevel. Defaults to `debug`. Possible values `error`, `warning`, `info`, `verbose`, `debug`, `silly`
     logDatadogEvents: true, // boolean. It defaults to `true`
-    silent: true // boolean. It defaults to `true`
+    silent: true, // boolean. It defaults to `true`
+    tags: ['environment:production', 'version:1.2.3'], // allows transport level tagging in datadog
+    title: 'test-title' // string. It defaults to empty and can be overridden in the log messages
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { DogapiTransport } from './transports/dogapi-transport';
+import { DogapiTransportOptions } from './transports/dogapi-transport-options';
+
 export { Logger } from './logger/logger';
 export { WinstonEvent } from './events/winston-event.enum';
-export { DogapiTransport as Transport } from './transports/dogapi-transport';
+
+export const Transport = (options: DogapiTransportOptions) => new DogapiTransport({ dogapiTransportOptions: options });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { Logger } from './logger/logger';
 export { WinstonEvent } from './events/winston-event.enum';
-export { DogApiTransport as Transport } from './transports/dogapi-transport';
+export { DogapiTransport as Transport } from './transports/dogapi-transport';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Logger } from './logger/logger';
 export { WinstonEvent } from './events/winston-event.enum';
+export { DogApiTransport as Transport } from './transports/dogapi-transport';

--- a/src/transports/dogapi-transport-options.interface.ts
+++ b/src/transports/dogapi-transport-options.interface.ts
@@ -1,6 +1,7 @@
 import { TransportStreamOptions } from 'winston-transport';
 import { WinstonEvent } from '..';
 import { NullableString } from '../types/nullable-string.type';
+import { NullableStringArray } from '../types/nullable-string-array.type';
 
 export interface IDogapiTransportOptions extends TransportStreamOptions {
   level: WinstonEvent;
@@ -8,4 +9,6 @@ export interface IDogapiTransportOptions extends TransportStreamOptions {
   apiKey: NullableString;
   appKey: NullableString;
   logDatadogEvents: boolean;
+  tags: NullableStringArray;
+  title: NullableString;
 }

--- a/src/transports/dogapi-transport-options.ts
+++ b/src/transports/dogapi-transport-options.ts
@@ -1,8 +1,15 @@
 import { WinstonEvent } from '..';
 import { NullableString } from '../types/nullable-string.type';
+import { NullableStringArray } from '../types/nullable-string-array.type';
 import { IDogapiTransportOptions } from './dogapi-transport-options.interface';
 
 export class DogapiTransportOptions implements IDogapiTransportOptions {
+  private static getTags(options?: IDogapiTransportOptions) {
+    return options && options.hasOwnProperty('tags') ? options.tags : null;
+  }
+  private static getTitle(options?: IDogapiTransportOptions) {
+    return options && options.hasOwnProperty('title') ? options.title : null;
+  }
   private static getLogDatadogEvents(options?: IDogapiTransportOptions) {
     return options && options.hasOwnProperty('logDatadogEvents') ? options.logDatadogEvents : true;
   }
@@ -27,6 +34,8 @@ export class DogapiTransportOptions implements IDogapiTransportOptions {
   public handleExceptions: boolean;
   public level: WinstonEvent;
   public logDatadogEvents: boolean;
+  public tags: NullableStringArray;
+  public title: NullableString;
 
   constructor(options?: IDogapiTransportOptions) {
     this.apiKey = DogapiTransportOptions.getApiKey(options);
@@ -34,5 +43,7 @@ export class DogapiTransportOptions implements IDogapiTransportOptions {
     this.handleExceptions = DogapiTransportOptions.getHandleExceptions(options);
     this.level = DogapiTransportOptions.getLevel(options);
     this.logDatadogEvents = DogapiTransportOptions.getLogDatadogEvents(options);
+    this.tags = DogapiTransportOptions.getTags(options);
+    this.title = DogapiTransportOptions.getTitle(options);
   }
 }

--- a/src/transports/dogapi-transport.ts
+++ b/src/transports/dogapi-transport.ts
@@ -48,23 +48,22 @@ export class DogapiTransport extends TransportStream {
     // Formatting the date in milliseconds
     const formattedDate = new Date(timestamp).valueOf() / 1000;
 
-    const environment = this.options.environment;
-    const instance = this.options.instance;
-
     // Creating the options
     const properties = {
       alert_type: eventType,
       date_happened: formattedDate,
       tags: [
-        `environment:${environment}`,
-        `instance:${instance}`,
+        ...(this.options.dogapiTransportOptions.tags || [
+          `environment:${this.options.environment}`,
+          `instance:${this.options.instance}`,
+        ]),
         `request-id:${requestId}`,
         `internal-request-id:${internalRequestId}`,
       ],
     };
 
     // Instead of null we can put a callback for some additional action
-    dogapi.event.create(title, message, properties, (err: any, res: any) => {
+    dogapi.event.create(title || this.options.dogapiTransportOptions.title, message, properties, (err: any, res: any) => {
       if (this.options.dogapiTransportOptions.logDatadogEvents) {
         // tslint:disable-next-line:no-console
         console.log('Datadog event response: ', res);

--- a/src/types/nullable-string-array.type.ts
+++ b/src/types/nullable-string-array.type.ts
@@ -1,0 +1,1 @@
+export type NullableStringArray = string[] | null;


### PR DESCRIPTION
Hey, this is a really cool repo! However, I see this repo has roughly 7 times more weekly downloads on npm, even though it doesn't work with the latest version of Winstonjs:

https://www.npmjs.com/package/winston-datadog

I think you could basically take over that traffic if you offered the Transport layer here as a standalone thing to interact with. I've made some slight changes to expose the dogapi-transport as well as similar options (tags and title). I'm going to test it for functionality shortly. Let me know if you'd like me to get this to be merge-able. I haven't tried to run tsc to test yet, but will shortly. Thanks again! 