### PR TITLE
Fix(transport): apply default logger options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,23 @@ Logger.initialize(options);
 Logger.log(WinstonEvent.Debug, 'example message', {'title': 'your-title'});
 ```
 
+Additionally, the library provides a `Transport` instance if composing your own logger.
+This is consumed similarly to the logger, albeit with fewer options 
+
+```typescript
+import * as winston from 'winston';
+import { Transport as DatadogTransport } from 'winston-datadog-logger';
+
+const options = { /* same as above */ };
+
+const logger = winston.createLogger({
+  transports: [DatadogTransport(
+    options.dogapiTransportOptions,
+    options,
+  )],
+});
+
+logger.log('debug', 'example message', { 'title': 'your-title' });
+```
+
+The second argument is optional, merely an escape hatch for any overrides from the larger logger options above. The only 

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ const logger = winston.createLogger({
 logger.log('debug', 'example message', { 'title': 'your-title' });
 ```
 
-The second argument is optional, merely an escape hatch for any overrides from the larger logger options above. The only 
+The second argument is optional, merely an escape hatch for any overrides from the larger logger options above.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-import { DogapiTransport } from './transports/dogapi-transport';
-import { DogapiTransportOptions } from './transports/dogapi-transport-options';
-
 export { Logger } from './logger/logger';
 export { WinstonEvent } from './events/winston-event.enum';
-
-export const Transport = (options: DogapiTransportOptions) => new DogapiTransport({ dogapiTransportOptions: options });
+export { DogapiTransportStandalone as Transport } from './transports/dogapi-transport-standalone';

--- a/src/transports/dogapi-transport-standalone.ts
+++ b/src/transports/dogapi-transport-standalone.ts
@@ -1,0 +1,12 @@
+import { LoggerOptions } from '../logger-options/logger-options';
+import { DogapiTransport } from './dogapi-transport';
+import { DogapiTransportOptions } from './dogapi-transport-options';
+import { Logger } from '../logger/logger';
+
+export const DogapiTransportStandalone = (
+  ddOptions: DogapiTransportOptions,
+  options: LoggerOptions = new LoggerOptions(),
+) => new DogapiTransport({
+  ...options,
+  dogapiTransportOptions: ddOptions,
+});

--- a/src/transports/dogapi-transport-standalone.ts
+++ b/src/transports/dogapi-transport-standalone.ts
@@ -1,7 +1,6 @@
 import { LoggerOptions } from '../logger-options/logger-options';
 import { DogapiTransport } from './dogapi-transport';
 import { DogapiTransportOptions } from './dogapi-transport-options';
-import { Logger } from '../logger/logger';
 
 export const DogapiTransportStandalone = (
   ddOptions: DogapiTransportOptions,


### PR DESCRIPTION
Hey, the new transport is working great, except that I'm hitting an issue with the logger level mappings option supplied by the parent options. This allows for supplying the other options as needed. If you'd like, I can change the shape of this API. This doesn't change the consuming pattern. 

Also I tried to add some documentation in the readme as well.

Let me know your thoughts, if you'd like me to change anything, please flag me by name here. For some reason, I miss a lot of updates unless my name is used in them. Thanks again!
